### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup conda environment
         uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
Automated update of GitHub Actions to versions that run on the Node.js 24 runtime, replacing deprecated Node.js 16/20 versions.

All workflow YAML changes are limited to official GitHub Actions major version bumps (e.g. `actions/checkout`, `actions/setup-python`, etc.).